### PR TITLE
Properly construct the port for the endpoint

### DIFF
--- a/graphqshell/config/config.yaml
+++ b/graphqshell/config/config.yaml
@@ -2,9 +2,6 @@ application:
   tickrate: 1000000 # microseconds
 
 endpoints:
-  - name: demo_server
-    default: true
-    url: "http://demo_server:5000/graphql"
   - name: example 
     default: false
     url: "https://api.react-finland.fi/graphql"

--- a/graphqshell/config/config.yaml
+++ b/graphqshell/config/config.yaml
@@ -3,7 +3,7 @@ application:
 
 endpoints:
   - name: example 
-    default: false
+    default: true
     url: "https://api.react-finland.fi/graphql"
     link: "https://api.react-finland.fi/graphql"
   - name: weather


### PR DESCRIPTION
fixes #24 

This fixes the use of the correct port. Before it wasn't actually extracted from the URL. I had expected req to do the right thing here but I was mistaken. 